### PR TITLE
chore(renovate): track Minecraft versions via custom Mojang datasource

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-    minecraft(libs.minecraft)
+    minecraft("com.mojang:minecraft:${libs.versions.minecraft.get()}")
     implementation(libs.fabric.loader)
     implementation(libs.fabric.api)
     implementation(libs.modmenu)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,6 @@ kotlin = "2.3.21"
 minotaur = "2.9.0"
 
 [libraries]
-minecraft = { module = "com.mojang:minecraft", version.ref = "minecraft" }
 fabric-loader = { module = "net.fabricmc:fabric-loader", version.ref = "loader" }
 fabric-api = { module = "net.fabricmc.fabric-api:fabric-api", version.ref = "fabric-api" }
 fabric-language-kotlin = { module = "net.fabricmc:fabric-language-kotlin", version.ref = "fabric-language-kotlin" }

--- a/renovate.json
+++ b/renovate.json
@@ -7,25 +7,12 @@
   "ignoreDeps": [
     "com.mojang:minecraft"
   ],
-  "packageRules": [
-    {
-      "description": "Fabric Maven registry",
-      "matchPackagePrefixes": ["net.fabricmc"],
-      "registryUrls": ["https://maven.fabricmc.net/"]
-    },
-    {
-      "description": "Minecraft version bumps are notification-only",
-      "matchPackageNames": ["minecraft"],
-      "draftPR": true,
-      "labels": ["minecraft-update", "manual-action-required"]
-    }
-  ],
   "customDatasources": {
     "minecraft": {
       "defaultRegistryUrlTemplate": "https://piston-meta.mojang.com/mc/game/version_manifest_v2.json",
       "format": "json",
       "transformTemplates": [
-        "{ \"releases\": versions[type='release'].{ \"version\": id } }"
+        "{ \"releases\": versions[type='release'].{ \"version\": id, \"releaseTimestamp\": releaseTime } }"
       ]
     }
   },
@@ -35,7 +22,36 @@
       "fileMatch": ["^gradle/libs\\.versions\\.toml$"],
       "matchStrings": ["minecraft = \"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "minecraft",
+      "versioningTemplate": "semver-coerced",
       "datasourceTemplate": "custom.minecraft"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Fabric Maven registry",
+      "matchPackagePrefixes": ["net.fabricmc"],
+      "registryUrls": ["https://maven.fabricmc.net/"]
+    },
+    {
+      "description": "TerraformersMC registry for modmenu",
+      "matchPackageNames": ["com.terraformersmc:modmenu"],
+      "registryUrls": ["https://maven.terraformersmc.com/"]
+    },
+    {
+      "description": "Shedaniel registry for cloth-config",
+      "matchPackageNames": ["me.shedaniel.cloth:cloth-config-fabric"],
+      "registryUrls": ["https://maven.shedaniel.me/"]
+    },
+    {
+      "description": "Minecraft updates are notification-only",
+      "matchPackageNames": ["minecraft"],
+      "draftPR": true,
+      "labels": ["minecraft-update", "manual-action-required"]
+    },
+    {
+      "description": "Fabric API bugfixes can be merged directly",
+      "matchPackageNames": ["net.fabricmc.fabric-api:fabric-api"],
+      "labels": ["dependencies"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -8,21 +8,24 @@
     {
       "matchPackageNames": ["net.fabricmc{/,}**"],
       "registryUrls": ["https://maven.fabricmc.net/"]
-    },
-    {
-      "matchDepNames": ["minecraft"],
-      "matchDatasources": ["json"],
-      "allowedVersions": "/^\\d+(\\.\\d+)+$/"
     }
   ],
+  "customDatasources": {
+    "minecraft": {
+      "defaultRegistryUrlTemplate": "https://piston-meta.mojang.com/mc/game/version_manifest_v2.json",
+      "format": "json",
+      "transformTemplates": [
+        "{ \"releases\": versions[type='release'].{ \"version\": id } }"
+      ]
+    }
+  },
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^gradle/libs.versions.toml$"],
+      "fileMatch": ["^gradle/libs\\.versions\\.toml$"],
       "matchStrings": ["minecraft = \"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "minecraft",
-      "datasourceTemplate": "json",
-      "registryUrlTemplate": "https://piston-meta.mojang.com/mc/game/version_manifest_v2.json"
+      "datasourceTemplate": "custom.minecraft"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -6,12 +6,23 @@
   ],
   "packageRules": [
     {
-      "matchPackageNames": ["com.mojang:minecraft"],
-      "registryUrls": ["https://libraries.minecraft.net/"]
+      "matchPackageNames": ["net.fabricmc{/,}**"],
+      "registryUrls": ["https://maven.fabricmc.net/"]
     },
     {
-      "matchPackagePrefixes": ["net.fabricmc"],
-      "registryUrls": ["https://maven.fabricmc.net/"]
+      "matchDepNames": ["minecraft"],
+      "matchDatasources": ["json"],
+      "allowedVersions": "/^\\d+(\\.\\d+)+$/"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^gradle/libs.versions.toml$"],
+      "matchStrings": ["minecraft = \"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "minecraft",
+      "datasourceTemplate": "json",
+      "registryUrlTemplate": "https://piston-meta.mojang.com/mc/game/version_manifest_v2.json"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -4,10 +4,20 @@
     "config:recommended",
     ":disableDependencyDashboard"
   ],
+  "ignoreDeps": [
+    "com.mojang:minecraft"
+  ],
   "packageRules": [
     {
-      "matchPackageNames": ["net.fabricmc{/,}**"],
+      "description": "Fabric Maven registry",
+      "matchPackagePrefixes": ["net.fabricmc"],
       "registryUrls": ["https://maven.fabricmc.net/"]
+    },
+    {
+      "description": "Minecraft version bumps are notification-only",
+      "matchPackageNames": ["minecraft"],
+      "draftPR": true,
+      "labels": ["minecraft-update", "manual-action-required"]
     }
   ],
   "customDatasources": {


### PR DESCRIPTION
## Summary

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/JaroxCraft/codesmith/gommemode/pr/20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the Minecraft dependency declaration to explicit Maven coordinates instead of the version-catalog alias, and removed the corresponding catalog entry.
  * Updated dependency automation: ignore com.mojang by default, add custom Minecraft datasource/manager logic, route Fabric artifacts to the Fabric registry, and create draft PRs labeled for Minecraft updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaroxCraft/gommemode/pull/20)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->