### PR TITLE
feat(i18n): add German translation and fix key namespace

### DIFF
--- a/src/main/resources/assets/gommemode/lang/de_de.json
+++ b/src/main/resources/assets/gommemode/lang/de_de.json
@@ -1,0 +1,10 @@
+{
+  "gommemode.change": "Der Gommemode wurde ",
+  "gommemode.stopped": "deaktiviert",
+  "gommemode.started": "aktiviert",
+  "gommemode.already_active": "Der Gommemode ist bereits aktiv.",
+  "gommemode.already_inactive": "Der Gommemode ist bereits inaktiv.",
+  "key.category.gommemode.general": "Gommemode",
+  "key.gommemode.toggle": "Gommemode umschalten",
+  "entity.gommemode.gomme": "GommeHD"
+}

--- a/src/main/resources/assets/gommemode/lang/en_us.json
+++ b/src/main/resources/assets/gommemode/lang/en_us.json
@@ -4,7 +4,7 @@
   "gommemode.started": "activated",
   "gommemode.already_active": "The Gommemode is already active.",
   "gommemode.already_inactive": "The Gommemode is already inactive.",
-  "category.gommemode.general": "Gommemode",
+  "key.category.gommemode.general": "Gommemode",
   "key.gommemode.toggle": "Toggle Gommemode",
   "entity.gommemode.gomme": "GommeHD"
 }


### PR DESCRIPTION
## Summary

Fixed the key category namespace from `category.gommemode.general` to `key.category.gommemode.general` in the English locale, and added a complete German (de_de) translation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/JaroxCraft/codesmith/gommemode/pr/23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * German language support added for Gommemode, providing complete translations for status changes, activation states, control toggles, entity references, and category labels.

* **Updates**
  * English localization key naming conventions have been standardized for consistency across language resource files.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaroxCraft/gommemode/pull/23)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->