### PR TITLE
fix: update fabric.mod.json license to GPL-3.0

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -12,7 +12,7 @@
     "homepage": "https://jarox.de"
   },
   "icon": "assets/gommemode/icon.png",
-  "license": "All-Rights-Reserved",
+  "license": "GPL-3.0",
   "environment": "client",
   "entrypoints": {
     "client": [


### PR DESCRIPTION
## Summary

Changed fabric.mod.json license field from All-Rights-Reserved to GPL-3.0 to match the project's actual license.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/JaroxCraft/codesmith/gommemode/pr/25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the mod license to GPL-3.0.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaroxCraft/gommemode/pull/25)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->