### PR TITLE
ci: exclude ktlintCheck from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,4 +23,4 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
 
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew build -x ktlintCheck


### PR DESCRIPTION
## Summary  
  
- Build workflow no longer fails on formatting issues by excluding `ktlintCheck` from the `./gradlew build` task. The `Lint` workflow continues to enforce formatting via `ktlintCheck`. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the build process to improve development efficiency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaroxCraft/gommemode/pull/34)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->