### PR TITLE
fix: reset mod state on proxy server switch

### DIFF
--- a/src/main/kotlin/de/jarox/gommemode/Gommemode.kt
+++ b/src/main/kotlin/de/jarox/gommemode/Gommemode.kt
@@ -105,6 +105,9 @@ class Gommemode :
         ClientPlayConnectionEvents.DISCONNECT.register { _, _ ->
             GommemodeManager.reset()
         }
+        ClientPlayConnectionEvents.JOIN.register { _, _, _ ->
+            GommemodeManager.reset()
+        }
     }
 
     companion object {

--- a/src/main/kotlin/de/jarox/gommemode/GommemodeManager.kt
+++ b/src/main/kotlin/de/jarox/gommemode/GommemodeManager.kt
@@ -23,9 +23,9 @@ object GommemodeManager {
     private val minecraft: Minecraft = Minecraft.getInstance()
     private var activeSound: SoundInstance? = null
     private var gommeEntity: GommeEntity? = null
-    private var lastToggleTick: Long = 0L
+    private var lastToggleTime: Long = 0L
 
-    private const val COOLDOWN_TICKS: Long = 20L // 1 second at 20 ticks/second
+    private const val COOLDOWN_MS: Long = 1000L // 1 second
     private const val SPAWN_RADIUS: Double = 2.0
     private const val PARTICLE_DENSITY: Double = 0.2
     private const val LOOK_DISTANCE: Double = 5.0
@@ -40,7 +40,7 @@ object GommemodeManager {
     fun reset() {
         stopSongAndRemoveEntity()
         isActive = false
-        lastToggleTick = 0L
+        lastToggleTime = 0L
     }
 
     /**
@@ -63,14 +63,14 @@ object GommemodeManager {
         player: LocalPlayer,
         level: ClientLevel,
     ) {
-        if (level.gameTime < lastToggleTick + COOLDOWN_TICKS) return
+        if (System.currentTimeMillis() < lastToggleTime + COOLDOWN_MS) return
 
         if (isActive) {
             deactivate()
         } else {
             activate(player, level)
         }
-        lastToggleTick = level.gameTime
+        lastToggleTime = System.currentTimeMillis()
     }
 
     private fun activate(


### PR DESCRIPTION
Fixes #35

This PR fixes the mod not responding after switching servers on proxy networks.

### Changes
- **Gommemode.kt**: Added `ClientPlayConnectionEvents.JOIN` handler that calls `GommemodeManager.reset()` as a safety net in addition to the existing `DISCONNECT` handler.
- **GommemodeManager.kt**: Replaced `level.gameTime`-based cooldown with `System.currentTimeMillis()`-based cooldown to make it independent of the server's game clock.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The mod now properly resets when players join a server, in addition to resetting on disconnect, for consistent behavior across all connection transitions.
  * Toggle cooldown timing has been updated to use real-time wall-clock timing with a standardized 1-second cooldown for improved reliability and predictable behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaroxCraft/gommemode/pull/36)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->