### PR TITLE
chore(deps): bump fabric-api to 0.148.2 and reorder version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 minecraft = "26.1.2"
-loader = "0.19.2"
-loom = "1.16.1"
-fabric-api = "0.147.0+26.1.2"
+kotlin = "2.3.21"
 fabric-language-kotlin = "1.13.11+kotlin.2.3.21"
+fabric-api = "0.148.2+26.1.2"
+loader = "0.19.2"
 modmenu = "18.0.0-beta.1"
 cloth-config = "26.1.154"
-kotlin = "2.3.21"
+loom = "1.16.1"
 ktlint = "14.2.0"
 minotaur = "2.9.0"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Fabric API dependency to the latest version.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaroxCraft/gommemode/pull/40)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->